### PR TITLE
feat(external-id): ExternalId now supports Yocto layers. (Completes INTCMN-410)

### DIFF
--- a/src/main/java/com/synopsys/integration/bdio/BdioTransformer.java
+++ b/src/main/java/com/synopsys/integration/bdio/BdioTransformer.java
@@ -93,9 +93,15 @@ public class BdioTransformer {
                     id.architecture = pieces[2];
                 }
             } else if (pieces[1].equals(name) && pieces[2].equals(revision)) {
-                id.group = pieces[0];
-                id.name = pieces[1];
-                id.version = pieces[2];
+                if (Forge.YOCTO.equals(forge)) {
+                    id.layer = pieces[0];
+                    id.name = pieces[1];
+                    id.version = pieces[2];
+                } else {
+                    id.group = pieces[0];
+                    id.name = pieces[1];
+                    id.version = pieces[2];
+                }
             } else {
                 id.moduleNames = pieces;
             }

--- a/src/main/java/com/synopsys/integration/bdio/SimpleBdioFactory.java
+++ b/src/main/java/com/synopsys/integration/bdio/SimpleBdioFactory.java
@@ -155,6 +155,10 @@ public class SimpleBdioFactory {
         return externalIdFactory.createNameVersionExternalId(forge, name, version);
     }
 
+    public ExternalId createYoctoExternalId(String layer, String name, String version) {
+        return externalIdFactory.createYoctoExternalId(layer, name, version);
+    }
+
     public ExternalId createMavenExternalId(String group, String name, String version) {
         return externalIdFactory.createMavenExternalId(group, name, version);
     }

--- a/src/main/java/com/synopsys/integration/bdio/model/externalid/ExternalId.java
+++ b/src/main/java/com/synopsys/integration/bdio/model/externalid/ExternalId.java
@@ -34,6 +34,7 @@ import com.synopsys.integration.util.Stringable;
 
 public class ExternalId extends Stringable {
     public final Forge forge;
+    public String layer;
     public String group;
     public String name;
     public String version;
@@ -50,6 +51,7 @@ public class ExternalId extends Stringable {
      * external id type you need. The currently supported types are:
      * "name/version": populate name and version (if version is blank, only name is included)
      * "architecture": populate name, version, and architecture (if version is blank, only name is included)
+     * "layer": populate name, version, and layer (if version is blank, only name is included)
      * "maven": populate name, version, and group (if version is blank, group and name are included)
      * "module names": populate moduleNames
      * "path": populate path
@@ -64,6 +66,8 @@ public class ExternalId extends Stringable {
                 return new String[] { group, name, version };
             } else if (StringUtils.isNotBlank(architecture)) {
                 return new String[] { name, version, architecture };
+            } else if (StringUtils.isNotBlank(layer)) {
+                return new String[] { layer, name, version };
             } else {
                 return new String[] { name, version };
             }
@@ -71,6 +75,8 @@ public class ExternalId extends Stringable {
             //Black Duck now (2019.6.0) supports version-less components
             if (StringUtils.isNotBlank(group)) {
                 return new String[] { group, name };
+            } else if (StringUtils.isNotBlank(layer)) {
+                return new String[] { layer, name };
             } else {
                 return new String[] { name };
             }
@@ -79,7 +85,7 @@ public class ExternalId extends Stringable {
         // if we can't be positive about what kind of external id we are, just give everything we have in a reasonable order
         List<String> bestGuessPieces = new ArrayList<>();
 
-        List<String> bestGuessCandidates = Arrays.asList(group, name, version, architecture);
+        final List<String> bestGuessCandidates = Arrays.asList(layer, group, name, version, architecture);
         for (String candidate : bestGuessCandidates) {
             if (StringUtils.isNotBlank(candidate)) {
                 bestGuessPieces.add(candidate);

--- a/src/main/java/com/synopsys/integration/bdio/model/externalid/ExternalIdFactory.java
+++ b/src/main/java/com/synopsys/integration/bdio/model/externalid/ExternalIdFactory.java
@@ -33,6 +33,13 @@ public class ExternalIdFactory {
         return externalId;
     }
 
+    public ExternalId createYoctoExternalId(final String layer, final String name, final String version) {
+        final ExternalId externalId = createNameVersionExternalId(Forge.YOCTO, name, version);
+        externalId.layer = layer;
+        checkForValidity(externalId);
+        return externalId;
+    }
+
     public ExternalId createMavenExternalId(final String group, final String name, final String version) {
         final ExternalId externalId = createNameVersionExternalId(Forge.MAVEN, name, version);
         externalId.group = group;

--- a/src/test/java/com/synopsys/integration/bdio/model/externalid/ExternalIdTest.java
+++ b/src/test/java/com/synopsys/integration/bdio/model/externalid/ExternalIdTest.java
@@ -37,6 +37,10 @@ public class ExternalIdTest {
         ExternalId pathExternalId = simpleBdioFactory.createPathExternalId(Forge.GOGET, "name");
         assertEquals(new BdioId("http:goget/name"), pathExternalId.createBdioId());
         assertEquals("name", pathExternalId.createExternalId());
+
+        ExternalId yoctoExternalId = simpleBdioFactory.createYoctoExternalId("layer", "name", "version");
+        assertEquals(new BdioId("http:yocto/layer/name/version"), yoctoExternalId.createBdioId());
+        assertEquals("layer/name/version", yoctoExternalId.createExternalId());
     }
 
     @Test
@@ -84,6 +88,13 @@ public class ExternalIdTest {
         ExternalId externalId = simpleBdioFactory.createNameVersionExternalId(Forge.RUBYGEMS, "thename", null);
         assertEquals("thename", externalId.createExternalId());
         assertEquals(new BdioId("http:rubygems/thename"), externalId.createBdioId());
+    }
+
+    @Test
+    public void testYoctoWithoutVersion() {
+        ExternalId externalId = simpleBdioFactory.createYoctoExternalId("thelayer", "thename", null);
+        assertEquals("thelayer/thename", externalId.createExternalId());
+        assertEquals(new BdioId("http:yocto/thelayer/thename"), externalId.createBdioId());
     }
 
     @Test


### PR DESCRIPTION
Yocto requires a layer/name/revision style ExternalId similar to maven's group field. This PR adds support for this to ExternalId related classes.