### PR TITLE
Add Eclipse forge to ExternalIdFactory given edge case seen in IDETECT-3181

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 project.ext.moduleName = 'com.synopsys.integration.integration-bdio'
 project.ext.javaUseAutoModuleName = 'true'
 
-version = '26.0.12-SNAPSHOT'
+version = '26.0.12'
 description = 'A library to allow for easy and clear creation of Black Duck I/O (bdio) documents.'
 
 apply plugin: 'com.synopsys.integration.library'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 project.ext.moduleName = 'com.synopsys.integration.integration-bdio'
 project.ext.javaUseAutoModuleName = 'true'
 
-version = '26.0.12'
+version = '26.0.12-SNAPSHOT'
 description = 'A library to allow for easy and clear creation of Black Duck I/O (bdio) documents.'
 
 apply plugin: 'com.synopsys.integration.library'

--- a/src/main/java/com/synopsys/integration/bdio/model/Forge.java
+++ b/src/main/java/com/synopsys/integration/bdio/model/Forge.java
@@ -35,6 +35,7 @@ public class Forge extends Stringable {
     public static final Forge CRAN = new Forge("/", "cran");
     public static final Forge DART = new Forge("/", "dart");
     public static final Forge DEBIAN = new Forge("/", "debian");
+    public static final Forge ECLIPSE = new Forge("/", "eclipse");
     public static final Forge FEDORA = new Forge("/", "fedora");
     public static final Forge FREEDESKTOP_ORG = new Forge("/", "freedesktop_org");
     public static final Forge GITCAFE = new Forge("/", "gitcafe");

--- a/src/main/java/com/synopsys/integration/bdio/model/externalid/ExternalIdFactory.java
+++ b/src/main/java/com/synopsys/integration/bdio/model/externalid/ExternalIdFactory.java
@@ -47,6 +47,11 @@ public class ExternalIdFactory {
         return createYoctoExternalId(layer, name, null);
     }
 
+    public ExternalId createEclipseExternalId(String name, String version) {
+        ExternalId externalId = createNameVersionExternalId(Forge.ECLIPSE, name, version);
+        checkForValidity(externalId);
+        return externalId;
+    }
     public ExternalId createMavenExternalId(String group, String name, String version) {
         ExternalId externalId = createNameVersionExternalId(Forge.MAVEN, name, version);
         externalId.setGroup(group);


### PR DESCRIPTION
Eclipse has its own dependency management system called "[P2](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fp2_overview.htm)". IDETECT-3181 is a ticket asking Detect to adjust the way we generate external IDs for Eclipse components so that they may match with what KB has. When the example project given in IDETECT-3181 is scanned, https://github.com/LorenzoBettini/packtpub-xtext-book-2nd-examples, we get 174 components that have no match in the KB. One example is org.eclipse.core.runtime:
![1](https://github.com/blackducksoftware/synopsys-detect/assets/121134650/362b18f6-a0a5-4281-9d32-359abebbf770)

The Maven CLI Detector parses the output of mvn dependency:tree to generate the BDIO. This is what the entry in the tree looks like for the component above:

![image](https://github.com/blackducksoftware/synopsys-detect/assets/121134650/2d8d4516-41f2-4608-b6b5-9d4c490c3d4d)

And this is what the BDIO entry looks like:

![image](https://github.com/blackducksoftware/synopsys-detect/assets/121134650/00d29cac-934a-4890-98b3-d90c7d35bbfd)


This MR changes the way we generate external IDs for components that Detect identifies as an Eclipse package (See https://github.com/blackducksoftware/synopsys-detect/pull/1104). For example:

External ID before: p2.eclipse-plugin:org.eclipse.core.runtime:3.17.100.v20200203-0917
External ID after: org.eclipse.core.runtime/3.17.100.v20200203-0917