### PR TITLE
Add Opam Forge for dependency identification

### DIFF
--- a/src/main/java/com/synopsys/integration/bdio/model/Forge.java
+++ b/src/main/java/com/synopsys/integration/bdio/model/Forge.java
@@ -60,6 +60,7 @@ public class Forge extends Stringable {
     public static final Forge SOURCEFORGE_JP = new Forge("/", "sourceforge_jp");
     public static final Forge UBUNTU = new Forge("/", "ubuntu");
     public static final Forge YOCTO = new Forge("/", "yocto", true);
+    public static final Forge OPAM = new Forge("/", "opam");
 
     // forges that use the colon as the separator
     public static final Forge ANDROID = new Forge(":", "android");


### PR DESCRIPTION
Made this change to identify new opam packages for ocaml langauage. This is part of ticket IDETECT-4395 which will support the identification and scanning of OPAM package managers. The creation of external Ids will be similar to npm.