### PR TITLE
Provide non-reflection implementations for some inefficient methods

### DIFF
--- a/src/main/java/com/blackduck/integration/bdio/graph/builder/LazyId.java
+++ b/src/main/java/com/blackduck/integration/bdio/graph/builder/LazyId.java
@@ -14,6 +14,9 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 import static com.blackduck.integration.bdio.graph.builder.LazyIdSource.*;
 
 /**
@@ -45,4 +48,34 @@ public class LazyId extends Stringable {
         this.pieces.addAll(pieces);
     }
 
+    @Override
+    public int hashCode() {
+        return pieces.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof LazyId))
+            return false;
+
+        final LazyId other = (LazyId) obj;
+        return pieces.equals(other.pieces);
+    }
+
+    /**
+     * Since the only instance variable never gets modified, we store toString() results for efficiency.
+     */
+    private String toStringResult;
+
+    @Override
+    public String toString() {
+        if (toStringResult == null) {
+            toStringResult = new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
+                .append("pieces", pieces)
+                .build();
+        }
+        return toStringResult;
+    }
 }

--- a/src/main/java/com/blackduck/integration/bdio/model/Forge.java
+++ b/src/main/java/com/blackduck/integration/bdio/model/Forge.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -136,4 +137,22 @@ public class Forge extends Stringable {
         return separator;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, separator, usePreferredNamespaceAlias);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Forge)) {
+            return false;
+        }
+        Forge that = (Forge) obj;
+        return Objects.equals(name, that.name) &&
+               Objects.equals(separator, that.separator) &&
+               Objects.equals(usePreferredNamespaceAlias, that.usePreferredNamespaceAlias);
+    }
 }

--- a/src/main/java/com/blackduck/integration/bdio/model/dependency/Dependency.java
+++ b/src/main/java/com/blackduck/integration/bdio/model/dependency/Dependency.java
@@ -7,6 +7,11 @@
  */
 package com.blackduck.integration.bdio.model.dependency;
 
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.util.Stringable;
 
@@ -90,5 +95,35 @@ public class Dependency extends Stringable {
 
     public void setScope(String scope) {
         this.scope = scope;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, version, externalId, scope);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Dependency)) {
+            return false;
+        }
+        Dependency that = (Dependency) obj;
+        return Objects.equals(name, that.name) &&
+               Objects.equals(version, that.version) &&
+               Objects.equals(externalId, that.externalId) &&
+               Objects.equals(scope, that.scope);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
+            .append("name", name)
+            .append("version", version)
+            .append("externalId", externalId)
+            .append("scope", scope)
+            .build();
     }
 }

--- a/src/main/java/com/blackduck/integration/bdio/model/externalid/ExternalId.java
+++ b/src/main/java/com/blackduck/integration/bdio/model/externalid/ExternalId.java
@@ -11,11 +11,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.blackduck.integration.bdio.model.BdioId;
 import com.blackduck.integration.bdio.model.Forge;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.blackduck.integration.util.Stringable;
 
@@ -234,4 +237,33 @@ public class ExternalId extends Stringable {
         return suffix;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(forge, pieces, prefix, suffix);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ExternalId)) {
+            return false;
+        }
+        ExternalId that = (ExternalId) obj;
+        return Objects.equals(forge, that.forge) &&
+               Objects.equals(pieces, that.pieces) &&
+               Objects.equals(prefix, that.prefix) &&
+               Objects.equals(suffix, that.suffix);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
+            .append("forge", forge)
+            .append("pieces", pieces)
+            .append("prefix", prefix)
+            .append("suffix", suffix)
+            .build();
+    }
 }


### PR DESCRIPTION
Provide non-reflection implementations for some inefficient methods.

The parent class of these classes relies on reflection for these methods which when dealing with very large projects contributes to very long scan times in Detect.

Link to parent class which provides the existing implementation: https://github.com/blackducksoftware/integration-common/blob/master/src/main/java/com/blackduck/integration/util/Stringable.java