### PR TITLE
Update integration-common for EU CRA fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ versionFile.delete()
 versionFile << version
 
 dependencies {
-    api 'com.blackduck.integration:integration-common:27.0.3'
+    api 'com.blackduck.integration:integration-common:27.0.4'
 
     testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation 'org.skyscreamer:jsonassert:1.5.1'


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5081

**Description**

 This pull request bumps integration-common version to `27.0.4`. The `integration-common:27.0.4` updates the direct dependency  `json-path` from `2.9.0` to `2.10.0` to resolve a transitive vulnerable dependency as part of the EU CRA compliance effort.
 
`json-path:2.9.0` pulls in `json-smart:2.5.0`, which carries **CVE-2024-57699 (BDSA-2025-0966)**. 
This update transitively brings in `json-smart:2.6.0`, which is free of this vulnerability, and thus the safe version flows to all downstream consumers automatically.